### PR TITLE
fix kratos in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos-layout
 go 1.15
 
 require (
-	github.com/go-kratos/kratos/v2 v2.0.0-20210218084952-db763a2cdc87
+	github.com/go-kratos/kratos/v2 latest
 	github.com/golang/protobuf v1.4.3
 	github.com/google/subcommands v1.2.0 // indirect
 	github.com/google/wire v0.5.0


### PR DESCRIPTION
Fix `go: github.com/go-kratos/kratos/v2@v2.0.0-20210218084952-db763a2cdc87: invalid version: unknown revision db763a2cdc87`  problem.

Reason:
1. It produces an error while building.
2. No specific version of kratos should be referenced in layout.

Signed-off-by: storyicon <storyicon@foxmail.com>