### PR TITLE
use helper to print log to avoid KEYVALS UNPAIRED

### DIFF
--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -17,7 +17,7 @@ type Data struct {
 // NewData .
 func NewData(c *conf.Data, logger log.Logger) (*Data, func(), error) {
 	cleanup := func() {
-		logger.Log(log.LevelInfo, "closing the data resources")
+		log.NewHelper(logger).Info("closing the data resources")
 	}
 	return &Data{}, cleanup, nil
 }


### PR DESCRIPTION
The original code will show "KEYVALS UNPAIRED" due to the lack of key.