### PR TITLE
chore(make): tidy mod after generate.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ generate:
 	go mod tidy
 	go get github.com/google/wire/cmd/wire@latest
 	go generate ./...
+	go mod tidy
 
 .PHONY: all
 # generate all

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-kratos/kratos/v2/transport/http"
 )
 
+//go:generate wire
 // go build -ldflags "-X main.Version=x.y.z"
 var (
 	// Name is the name of the compiled software.


### PR DESCRIPTION
It will pollute the pkg after `make generate`.
And wire gen is not work.

Refs: #91