### PR TITLE
refactor: format import group & add go:build directive

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/go-kratos/kratos-layout/internal/conf"
+
 	"github.com/go-kratos/kratos/v2"
 	"github.com/go-kratos/kratos/v2/config"
 	"github.com/go-kratos/kratos/v2/config/file"

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -1,3 +1,4 @@
+//go:build wireinject
 // +build wireinject
 
 // The build tag makes sure the stub is not built in the final build.

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-kratos/kratos-layout/internal/data"
 	"github.com/go-kratos/kratos-layout/internal/server"
 	"github.com/go-kratos/kratos-layout/internal/service"
+
 	"github.com/go-kratos/kratos/v2"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/wire"

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kratos/kratos-layout/internal/data"
 	"github.com/go-kratos/kratos-layout/internal/server"
 	"github.com/go-kratos/kratos-layout/internal/service"
+
 	"github.com/go-kratos/kratos/v2"
 	"github.com/go-kratos/kratos/v2/log"
 )

--- a/internal/biz/greeter.go
+++ b/internal/biz/greeter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	v1 "github.com/go-kratos/kratos-layout/api/helloworld/v1"
+
 	"github.com/go-kratos/kratos/v2/errors"
 	"github.com/go-kratos/kratos/v2/log"
 )

--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"github.com/go-kratos/kratos-layout/internal/conf"
+
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/wire"
 )

--- a/internal/data/greeter.go
+++ b/internal/data/greeter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-kratos/kratos-layout/internal/biz"
+
 	"github.com/go-kratos/kratos/v2/log"
 )
 

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -4,6 +4,7 @@ import (
 	v1 "github.com/go-kratos/kratos-layout/api/helloworld/v1"
 	"github.com/go-kratos/kratos-layout/internal/conf"
 	"github.com/go-kratos/kratos-layout/internal/service"
+
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/middleware/recovery"
 	"github.com/go-kratos/kratos/v2/transport/grpc"

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -4,6 +4,7 @@ import (
 	v1 "github.com/go-kratos/kratos-layout/api/helloworld/v1"
 	"github.com/go-kratos/kratos-layout/internal/conf"
 	"github.com/go-kratos/kratos-layout/internal/service"
+
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/middleware/recovery"
 	"github.com/go-kratos/kratos/v2/transport/http"


### PR DESCRIPTION
1. format imported package group
2. add build directive(//go:build) for go version 1.17 or newer