### PR TITLE
Update Makefile Git_Bash info get on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ ifeq ($(GOHOSTOS), windows)
 	#the `find.exe` is different from `find` in bash/shell.
 	#to see https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/find.
 	#changed to use git-bash.exe to run find cli or other cli friendly, caused of every developer has a Git.
-	Git_Bash= $(subst cmd\,bin\bash.exe,$(dir $(shell where git)))
+	#Git_Bash= $(subst cmd\,bin\bash.exe,$(dir $(shell where git)))
+	Git_Bash=$(subst \,/,$(subst cmd\,bin\bash.exe,$(dir $(shell where git | grep cmd))))
 	INTERNAL_PROTO_FILES=$(shell $(Git_Bash) -c "find internal -name *.proto")
 	API_PROTO_FILES=$(shell $(Git_Bash) -c "find api -name *.proto")
 else


### PR DESCRIPTION
Optimizing fetching of Git_Bash on Windows has issues with multipath and path escape characters