### PR TITLE
fix: Git_Bash path calculation error in windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ ifeq ($(GOHOSTOS), windows)
 	#the `find.exe` is different from `find` in bash/shell.
 	#to see https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/find.
 	#changed to use git-bash.exe to run find cli or other cli friendly, caused of every developer has a Git.
-	#Git_Bash= $(subst cmd\,bin\bash.exe,$(dir $(shell where git)))
-	Git_Bash=$(subst \,/,$(subst cmd\,bin\bash.exe,$(dir $(shell where git))))
+	#Git_Bash= $(subst cmd\git.exe,bin\bash.exe,$(shell where git))
+	Git_Bash="$(subst \,/,$(subst cmd\git.exe,bin\bash.exe,$(shell where git)))"
 	INTERNAL_PROTO_FILES=$(shell $(Git_Bash) -c "find internal -name *.proto")
 	API_PROTO_FILES=$(shell $(Git_Bash) -c "find api -name *.proto")
 else


### PR DESCRIPTION
The file sturcture of git it's looks like below in windows:

```sh
C://Program Files/Git$ tree -L 2 .
.
├── bin
│   ├── bash.exe # here is what makefile want to calculate for
│   ├── git.exe
│   └── sh.exe
├── cmd
│   ├── git-gui.exe
│   ├── git-lfs.exe
│   ├── git-receive-pack.exe
│   ├── git-upload-pack.exe
│   ├── git.exe # here is where git is
│   ├── gitk.exe
│   ├── scalar.exe
│   ├── start-ssh-agent.cmd
│   └── start-ssh-pageant.cmd
...
```

Makefile used the code below to calculate the path of "bash.exe". 

```makefile
Git_Bash=$(subst \,/,$(subst cmd\,bin\bash.exe,$(dir $(shell where git))))
```

But it used a wrong command `dir`. `dir` is a command like `ls .`, even in windows. So user that using windows can not get a correct "Git_Bash". And now I have fixed this issue.

Makefile 计算 bash.exe 路径的时候使用了一个叫 `dir` 的命令。这里的原意是想获取一个路径的目录名，例如 "/a/b/c.exe" -> "/a/b"。但 `dir` 实际上相当于 `ls .` ,就算在 windows 中也是这样。也就是说用错命令了。

不过 windows 里也没有 `dirname` 命令，所以我用了其他的手段解决问题。