### PR TITLE
optimize: set default config path

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,7 +30,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&flagconf, "conf", "../../configs", "config path, eg: -conf config.yaml")
+	flag.StringVar(&flagconf, "conf", "./configs", "config path, eg: -conf config.yaml")
 }
 
 func newApp(logger log.Logger, gs *grpc.Server, hs *http.Server) *kratos.App {


### PR DESCRIPTION
change config path, so goland can run directly without config file path forcefully.