### PR TITLE
fix(protobuf): upgrade protobuf version to avoid CVE-2024-24786

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	go.uber.org/automaxprocs v1.5.1
 	google.golang.org/genproto/googleapis/api v0.0.0-20230629202037-9506855d4529
 	google.golang.org/grpc v1.56.3
-	google.golang.org/protobuf v1.32.0
+	google.golang.org/protobuf v1.33.0
 )
 
 require (


### PR DESCRIPTION
due to https://github.com/protocolbuffers/protobuf-go/releases/tag/v1.33.0
say: 
protobuf 1.33.0 fix bug to avoid CVE-2024-24786