### PR TITLE
fix: replace hardcoded DB password in project template config

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -8,7 +8,7 @@ server:
 data:
   database:
     driver: mysql
-    source: root:root@tcp(127.0.0.1:3306)/test?parseTime=True&loc=Local
+    source: ${DB_DSN:root@tcp(127.0.0.1:3306)/test?parseTime=true&loc=Local}
   redis:
     addr: 127.0.0.1:6379
     read_timeout: 0.2s


### PR DESCRIPTION
## Summary

The project template config ships with a hardcoded MySQL root password. Every project created with `kratos new` inherits these credentials.

## What was there

**configs/config.yaml** — the template checked into the repo:

```yaml
data:
  database:
    driver: mysql
    source: root:root@tcp(127.0.0.1:3306)/test?parseTime=true&loc=Local
```

`root:root` is embedded in the DSN string. New projects start with these credentials unless the developer explicitly overwrites them.

## What changed

Replaced with an env var placeholder:

```yaml
data:
  database:
    driver: mysql
    source: ${DB_DSN:root@tcp(127.0.0.1:3306)/test?parseTime=true&loc=Local}
```

The host/port/db defaults are preserved but the password is no longer hardcoded in the template.

See also: CWE-798