### PR TITLE
fix(api): swap route registration order to prevent wildcard route hijacking list

### DIFF
--- a/api/todo/v1/todo.pb.go
+++ b/api/todo/v1/todo.pb.go
@@ -724,9 +724,9 @@ const file_todo_v1_todo_proto_rawDesc = "" +
 	"event_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\teventTime2\xe9\x04\n" +
 	"\vTodoService\x12W\n" +
 	"\n" +
-	"CreateTodo\x12\x1a.todo.v1.CreateTodoRequest\x1a\r.todo.v1.Todo\"\x1e\x82\xd3\xe4\x93\x02\x18:\x04todo\"\x10/v1/todos/create\x12I\n" +
-	"\aGetTodo\x12\x17.todo.v1.GetTodoRequest\x1a\r.todo.v1.Todo\"\x16\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/todos/{id}\x12P\n" +
-	"\tListTodos\x12\x19.todo.v1.ListTodosRequest\x1a\x10.todo.v1.TodoSet\"\x16\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/todos/list\x12W\n" +
+	"CreateTodo\x12\x1a.todo.v1.CreateTodoRequest\x1a\r.todo.v1.Todo\"\x1e\x82\xd3\xe4\x93\x02\x18:\x04todo\"\x10/v1/todos/create\x12P\n" +
+	"\tListTodos\x12\x19.todo.v1.ListTodosRequest\x1a\x10.todo.v1.TodoSet\"\x16\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/todos/list\x12I\n" +
+	"\aGetTodo\x12\x17.todo.v1.GetTodoRequest\x1a\r.todo.v1.Todo\"\x16\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/todos/{id}\x12W\n" +
 	"\n" +
 	"UpdateTodo\x12\x1a.todo.v1.UpdateTodoRequest\x1a\r.todo.v1.Todo\"\x1e\x82\xd3\xe4\x93\x02\x18:\x04todo\x1a\x10/v1/todos/update\x12X\n" +
 	"\n" +
@@ -776,15 +776,15 @@ var file_todo_v1_todo_proto_depIdxs = []int32{
 	0,  // 8: todo.v1.TodoEvent.todo:type_name -> todo.v1.Todo
 	10, // 9: todo.v1.TodoEvent.event_time:type_name -> google.protobuf.Timestamp
 	2,  // 10: todo.v1.TodoService.CreateTodo:input_type -> todo.v1.CreateTodoRequest
-	3,  // 11: todo.v1.TodoService.GetTodo:input_type -> todo.v1.GetTodoRequest
-	4,  // 12: todo.v1.TodoService.ListTodos:input_type -> todo.v1.ListTodosRequest
+	4,  // 11: todo.v1.TodoService.ListTodos:input_type -> todo.v1.ListTodosRequest
+	3,  // 12: todo.v1.TodoService.GetTodo:input_type -> todo.v1.GetTodoRequest
 	5,  // 13: todo.v1.TodoService.UpdateTodo:input_type -> todo.v1.UpdateTodoRequest
 	6,  // 14: todo.v1.TodoService.DeleteTodo:input_type -> todo.v1.DeleteTodoRequest
 	7,  // 15: todo.v1.TodoService.WatchTodos:input_type -> todo.v1.WatchTodosRequest
 	8,  // 16: todo.v1.TodoService.SyncTodos:input_type -> todo.v1.SyncTodoRequest
 	0,  // 17: todo.v1.TodoService.CreateTodo:output_type -> todo.v1.Todo
-	0,  // 18: todo.v1.TodoService.GetTodo:output_type -> todo.v1.Todo
-	1,  // 19: todo.v1.TodoService.ListTodos:output_type -> todo.v1.TodoSet
+	1,  // 18: todo.v1.TodoService.ListTodos:output_type -> todo.v1.TodoSet
+	0,  // 19: todo.v1.TodoService.GetTodo:output_type -> todo.v1.Todo
 	0,  // 20: todo.v1.TodoService.UpdateTodo:output_type -> todo.v1.Todo
 	12, // 21: todo.v1.TodoService.DeleteTodo:output_type -> google.protobuf.Empty
 	9,  // 22: todo.v1.TodoService.WatchTodos:output_type -> todo.v1.TodoEvent

--- a/api/todo/v1/todo.proto
+++ b/api/todo/v1/todo.proto
@@ -27,20 +27,20 @@ service TodoService {
     };
   }
 
-  // GetTodo returns a single todo item by its id.
-  // Returns NOT_FOUND if no todo exists with the supplied id.
-  rpc GetTodo (GetTodoRequest) returns (Todo) {
-    option (google.api.http) = {
-      get: "/v1/todos/{id}"
-    };
-  }
-
   // ListTodos returns a page of todo items, optionally filtered and ordered.
   // Use the next_page_token from TodoSet to retrieve subsequent pages.
   // Returns INVALID_ARGUMENT if filter, order_by, or page_token are malformed.
   rpc ListTodos (ListTodosRequest) returns (TodoSet) {
     option (google.api.http) = {
       get: "/v1/todos/list"
+    };
+  }
+
+  // GetTodo returns a single todo item by its id.
+  // Returns NOT_FOUND if no todo exists with the supplied id.
+  rpc GetTodo (GetTodoRequest) returns (Todo) {
+    option (google.api.http) = {
+      get: "/v1/todos/{id}"
     };
   }
 

--- a/api/todo/v1/todo_grpc.pb.go
+++ b/api/todo/v1/todo_grpc.pb.go
@@ -21,8 +21,8 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	TodoService_CreateTodo_FullMethodName = "/todo.v1.TodoService/CreateTodo"
-	TodoService_GetTodo_FullMethodName    = "/todo.v1.TodoService/GetTodo"
 	TodoService_ListTodos_FullMethodName  = "/todo.v1.TodoService/ListTodos"
+	TodoService_GetTodo_FullMethodName    = "/todo.v1.TodoService/GetTodo"
 	TodoService_UpdateTodo_FullMethodName = "/todo.v1.TodoService/UpdateTodo"
 	TodoService_DeleteTodo_FullMethodName = "/todo.v1.TodoService/DeleteTodo"
 	TodoService_WatchTodos_FullMethodName = "/todo.v1.TodoService/WatchTodos"
@@ -41,13 +41,13 @@ type TodoServiceClient interface {
 	// with the server-assigned id, create_time, and update_time populated.
 	// Returns INVALID_ARGUMENT if the request payload fails validation.
 	CreateTodo(ctx context.Context, in *CreateTodoRequest, opts ...grpc.CallOption) (*Todo, error)
-	// GetTodo returns a single todo item by its id.
-	// Returns NOT_FOUND if no todo exists with the supplied id.
-	GetTodo(ctx context.Context, in *GetTodoRequest, opts ...grpc.CallOption) (*Todo, error)
 	// ListTodos returns a page of todo items, optionally filtered and ordered.
 	// Use the next_page_token from TodoSet to retrieve subsequent pages.
 	// Returns INVALID_ARGUMENT if filter, order_by, or page_token are malformed.
 	ListTodos(ctx context.Context, in *ListTodosRequest, opts ...grpc.CallOption) (*TodoSet, error)
+	// GetTodo returns a single todo item by its id.
+	// Returns NOT_FOUND if no todo exists with the supplied id.
+	GetTodo(ctx context.Context, in *GetTodoRequest, opts ...grpc.CallOption) (*Todo, error)
 	// UpdateTodo applies a partial update to an existing todo item using a
 	// FieldMask. Only the fields listed in update_mask are overwritten; all
 	// other fields are left unchanged.
@@ -86,20 +86,20 @@ func (c *todoServiceClient) CreateTodo(ctx context.Context, in *CreateTodoReques
 	return out, nil
 }
 
-func (c *todoServiceClient) GetTodo(ctx context.Context, in *GetTodoRequest, opts ...grpc.CallOption) (*Todo, error) {
+func (c *todoServiceClient) ListTodos(ctx context.Context, in *ListTodosRequest, opts ...grpc.CallOption) (*TodoSet, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(Todo)
-	err := c.cc.Invoke(ctx, TodoService_GetTodo_FullMethodName, in, out, cOpts...)
+	out := new(TodoSet)
+	err := c.cc.Invoke(ctx, TodoService_ListTodos_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *todoServiceClient) ListTodos(ctx context.Context, in *ListTodosRequest, opts ...grpc.CallOption) (*TodoSet, error) {
+func (c *todoServiceClient) GetTodo(ctx context.Context, in *GetTodoRequest, opts ...grpc.CallOption) (*Todo, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(TodoSet)
-	err := c.cc.Invoke(ctx, TodoService_ListTodos_FullMethodName, in, out, cOpts...)
+	out := new(Todo)
+	err := c.cc.Invoke(ctx, TodoService_GetTodo_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -170,13 +170,13 @@ type TodoServiceServer interface {
 	// with the server-assigned id, create_time, and update_time populated.
 	// Returns INVALID_ARGUMENT if the request payload fails validation.
 	CreateTodo(context.Context, *CreateTodoRequest) (*Todo, error)
-	// GetTodo returns a single todo item by its id.
-	// Returns NOT_FOUND if no todo exists with the supplied id.
-	GetTodo(context.Context, *GetTodoRequest) (*Todo, error)
 	// ListTodos returns a page of todo items, optionally filtered and ordered.
 	// Use the next_page_token from TodoSet to retrieve subsequent pages.
 	// Returns INVALID_ARGUMENT if filter, order_by, or page_token are malformed.
 	ListTodos(context.Context, *ListTodosRequest) (*TodoSet, error)
+	// GetTodo returns a single todo item by its id.
+	// Returns NOT_FOUND if no todo exists with the supplied id.
+	GetTodo(context.Context, *GetTodoRequest) (*Todo, error)
 	// UpdateTodo applies a partial update to an existing todo item using a
 	// FieldMask. Only the fields listed in update_mask are overwritten; all
 	// other fields are left unchanged.
@@ -208,11 +208,11 @@ type UnimplementedTodoServiceServer struct{}
 func (UnimplementedTodoServiceServer) CreateTodo(context.Context, *CreateTodoRequest) (*Todo, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateTodo not implemented")
 }
-func (UnimplementedTodoServiceServer) GetTodo(context.Context, *GetTodoRequest) (*Todo, error) {
-	return nil, status.Error(codes.Unimplemented, "method GetTodo not implemented")
-}
 func (UnimplementedTodoServiceServer) ListTodos(context.Context, *ListTodosRequest) (*TodoSet, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListTodos not implemented")
+}
+func (UnimplementedTodoServiceServer) GetTodo(context.Context, *GetTodoRequest) (*Todo, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetTodo not implemented")
 }
 func (UnimplementedTodoServiceServer) UpdateTodo(context.Context, *UpdateTodoRequest) (*Todo, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateTodo not implemented")
@@ -265,24 +265,6 @@ func _TodoService_CreateTodo_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TodoService_GetTodo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetTodoRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(TodoServiceServer).GetTodo(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: TodoService_GetTodo_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(TodoServiceServer).GetTodo(ctx, req.(*GetTodoRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 func _TodoService_ListTodos_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ListTodosRequest)
 	if err := dec(in); err != nil {
@@ -297,6 +279,24 @@ func _TodoService_ListTodos_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TodoServiceServer).ListTodos(ctx, req.(*ListTodosRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TodoService_GetTodo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetTodoRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TodoServiceServer).GetTodo(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TodoService_GetTodo_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TodoServiceServer).GetTodo(ctx, req.(*GetTodoRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -367,12 +367,12 @@ var TodoService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _TodoService_CreateTodo_Handler,
 		},
 		{
-			MethodName: "GetTodo",
-			Handler:    _TodoService_GetTodo_Handler,
-		},
-		{
 			MethodName: "ListTodos",
 			Handler:    _TodoService_ListTodos_Handler,
+		},
+		{
+			MethodName: "GetTodo",
+			Handler:    _TodoService_GetTodo_Handler,
 		},
 		{
 			MethodName: "UpdateTodo",

--- a/api/todo/v1/todo_http.pb.go
+++ b/api/todo/v1/todo_http.pb.go
@@ -61,8 +61,8 @@ type TodoServiceHTTPServer interface {
 func RegisterTodoServiceHTTPServer(s *http.Server, srv TodoServiceHTTPServer) {
 	r := s.Route("/")
 	r.Handle("POST", "/v1/todos/create", _TodoService_CreateTodo0_HTTP_Handler(srv))
-	r.Handle("GET", "/v1/todos/{id}", _TodoService_GetTodo0_HTTP_Handler(srv))
 	r.Handle("GET", "/v1/todos/list", _TodoService_ListTodos0_HTTP_Handler(srv))
+	r.Handle("GET", "/v1/todos/{id}", _TodoService_GetTodo0_HTTP_Handler(srv))
 	r.Handle("PUT", "/v1/todos/update", _TodoService_UpdateTodo0_HTTP_Handler(srv))
 	r.Handle("DELETE", "/v1/todos/{id}", _TodoService_DeleteTodo0_HTTP_Handler(srv))
 	r.Handle("GET", "/v1/todos/watch", _TodoService_WatchTodos0_HTTP_Handler(srv))
@@ -114,6 +114,25 @@ func _TodoService_CreateTodo0_HTTP_Handler(srv TodoServiceHTTPServer) func(ctx h
 	}
 }
 
+func _TodoService_ListTodos0_HTTP_Handler(srv TodoServiceHTTPServer) func(ctx http.Context) error {
+	return func(ctx http.Context) error {
+		var in ListTodosRequest
+		if err := ctx.BindQuery(&in); err != nil {
+			return err
+		}
+		http.SetOperation(ctx, OperationTodoServiceListTodos)
+		h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
+			return srv.ListTodos(ctx, req.(*ListTodosRequest))
+		})
+		out, err := h(ctx, &in)
+		if err != nil {
+			return err
+		}
+		reply := out.(*TodoSet)
+		return ctx.Result(200, reply)
+	}
+}
+
 func _TodoService_GetTodo0_HTTP_Handler(srv TodoServiceHTTPServer) func(ctx http.Context) error {
 	return func(ctx http.Context) error {
 		var in GetTodoRequest
@@ -132,25 +151,6 @@ func _TodoService_GetTodo0_HTTP_Handler(srv TodoServiceHTTPServer) func(ctx http
 			return err
 		}
 		reply := out.(*Todo)
-		return ctx.Result(200, reply)
-	}
-}
-
-func _TodoService_ListTodos0_HTTP_Handler(srv TodoServiceHTTPServer) func(ctx http.Context) error {
-	return func(ctx http.Context) error {
-		var in ListTodosRequest
-		if err := ctx.BindQuery(&in); err != nil {
-			return err
-		}
-		http.SetOperation(ctx, OperationTodoServiceListTodos)
-		h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
-			return srv.ListTodos(ctx, req.(*ListTodosRequest))
-		})
-		out, err := h(ctx, &in)
-		if err != nil {
-			return err
-		}
-		reply := out.(*TodoSet)
 		return ctx.Result(200, reply)
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-kratos/kratos/contrib/otel/v3 v3.0.0-20260515082355-1ddb58e407c5 h1:FvzV+f61/k8ovG+ezFkF8S5rO3lNXKhYtmhaE91BIzg=
 github.com/go-kratos/kratos/contrib/otel/v3 v3.0.0-20260515082355-1ddb58e407c5/go.mod h1:hT2QNZ/0DPOvRqVqxoBBL/aMCOHhbbWh92mF87DBiCU=
-github.com/go-kratos/kratos/v3 v3.0.0-20260515082355-1ddb58e407c5 h1:oJP1LX4wDyA/VVSJXs1eSrDV2a4LNwX6PCmGHJrBsAU=
-github.com/go-kratos/kratos/v3 v3.0.0-20260515082355-1ddb58e407c5/go.mod h1:8l+0M5UPlm/5hWLvS+wzxHRVRv6sHMG6Lgb4+rw1KIs=
 github.com/go-kratos/kratos/v3 v3.0.0 h1:dCXqKoeo2Bo9jgC72YfuwJ3g7bPCkHeVeNGyZQ51bLE=
 github.com/go-kratos/kratos/v3 v3.0.0/go.mod h1:8l+0M5UPlm/5hWLvS+wzxHRVRv6sHMG6Lgb4+rw1KIs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -95,8 +93,6 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
### Description

In `api/todo/v1/todo.proto`, the `GetTodo` RPC (`/v1/todos/{id}`) was defined before the `ListTodos` RPC (`/v1/todos/list`). 

Because Kratos registers routes in the order they are defined in the Proto file, the generated HTTP handlers in `todo_http.pb.go` registered the wildcard route `/v1/todos/{id}` first. Consequently, requests to `GET /v1/todos/list` were intercepted by the `GetTodo` handler with `id="list"`, causing a decoding failure (400 Bad Request):
```json
{"code":400, "reason":"CODEC", "message":"parsing field \"id\": strconv.ParseInt: parsing \"list\": invalid syntax"}
```

### Changes
- Swapped `ListTodos` and `GetTodo` order in `api/todo/v1/todo.proto` to ensure `/v1/todos/list` is registered first.
- Regenerated the protobuf and HTTP client/server stubs.
### Verification & Testing
Tested locally with the HTTP server:
- `POST /v1/todos/create` succeeds.
- `GET /v1/todos/list` correctly hits the list endpoint and returns the collection list.
- `GET /v1/todos/{id}` correctly fetches single items and returns 404 for non-existent IDs.